### PR TITLE
Resource download link html tag update

### DIFF
--- a/ckanext/montreal_theme/templates/package/_read.html
+++ b/ckanext/montreal_theme/templates/package/_read.html
@@ -108,7 +108,7 @@
                             </td>
                             <td class="px-5 py-3 text-base text-primary" style="border-top-width: 1px;">
                                 <div style="display: flex; align-items:center; gap:10px;">
-                                <a href="{{ res.get('url') }}" target="_blank" style="width: 20px;">
+                                <a href="{{ res.get('url') }}" style="width: 20px;" download>
                                     <svg class="fill-current w-6 h-6 hover:rounded hover:bg-sarcelle-light" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="icon">
                                         <path fill-rule="evenodd" d="M12.376 15.927a1 1 0 01-1.083-.22l-5-5a1 1 0 011.414-1.414L11 12.586V3a1 1 0 012 0v12a1 1 0 01-.61.921zM20 15a1 1 0 012 0v4a3 3 0 01-3 3H5a3 3 0 01-3-3v-4a1 1 0 012 0v4a1 1 0 001 1h14a1 1 0 001-1v-4zm-3.707-5.707a1 1 0 011.414 1.414l-2 2a1 1 0 01-1.414-1.414l2-2z"></path>
                                     </svg>

--- a/ckanext/montreal_theme/templates/package/resource_read.html
+++ b/ckanext/montreal_theme/templates/package/resource_read.html
@@ -49,7 +49,7 @@
                 <div class="custom_panel">
                     <li class="mb-6">
                         <nav class="pt-4 pb-1">
-                            <a href="{{ h.url_for('resource.download', id=package.name, resource_id=resource.id) }}" class="inline-block mr-3 mb-6 py-2 px-4 rounded text-white bg-primary hover:bg-sarcelle-dark cursor-pointer" target="_blank">
+                            <a href="{{ h.url_for('resource.download', id=package.name, resource_id=resource.id) }}" class="inline-block mr-3 mb-6 py-2 px-4 rounded text-white bg-primary hover:bg-sarcelle-dark cursor-pointer" download>
                                 <dl class="data-file-type_inner">
                                     <dt class="data-file-type_term">{{ _("Download") + " (" + resource.format + ")" }}</dt>
                                 </dl>


### PR DESCRIPTION
Change in the html tag in download link so the link explicitly downloads the file instead of opening it in new tab of the browser.