### PR TITLE
Img tag lazy load attr setup

### DIFF
--- a/ckanext/montreal_theme/templates/home/snippets/all_organizations.html
+++ b/ckanext/montreal_theme/templates/home/snippets/all_organizations.html
@@ -3,7 +3,7 @@
     {% for org in organizations %}
     <li class="sm:w-1/3 lg:w-1/3 p-2">
         <a href="{{ h.url_for('organization.read', id=org.id) }}" class="p-4 block bg-white rounded hover:border-1 hover:border-solid hover:border-transparent hover:bg-white hover:shadow-xl hover:text-primary" style="border:1px solid #CED4DA">
-            <img class="h-20" src="{{ org.image_display_url }}"/>
+            <img class="h-20" src="{{ org.image_display_url }}" loading="lazy"/>
             <h2 class="text-xl h-16 font-bold flex items-center text-black">{{ org.title }}</h2>
         </a>
     </li>

--- a/ckanext/montreal_theme/templates/home/snippets/all_organizations_homepage.html
+++ b/ckanext/montreal_theme/templates/home/snippets/all_organizations_homepage.html
@@ -3,7 +3,7 @@
     {% for org in organizations[:3] %}
     <li class="sm:w-1/3 lg:w-1/3 p-2">
         <a href="{{ h.url_for('organization.read', id=org.id) }}" class="p-4 block bg-white rounded hover:border-1 hover:border-solid hover:border-transparent hover:bg-white hover:shadow-xl hover:text-primary" style="border:1px solid #CED4DA">
-            <img class="h-20" src="{{ org.image_display_url }}"/>
+            <img class="h-20" src="{{ org.image_display_url }}" loading="lazy"/>
             <h2 class="text-xl h-16 font-bold flex items-center text-black">{{ org.title }}</h2>
         </a>
     </li>

--- a/ckanext/montreal_theme/templates/home/snippets/applications.html
+++ b/ckanext/montreal_theme/templates/home/snippets/applications.html
@@ -3,9 +3,9 @@
     <a href="{{ h.url_for('showcase.read', id=showcase.name) }}" class="block m-4 hover:border-1 hover:border-solid hover:border-transparent hover:bg-white hover:shadow-xl">
         <div class="card-img">
             {% if image_url and not image_url.startswith('http') %}
-                <img class="rounded-t" src="/uploads/showcase/{{ image_url }}" alt="{{ showcase.title }}" style="width: calc(100% + 2px); height: 205px; object-fit: cover;">
+                <img class="rounded-t" src="/uploads/showcase/{{ image_url }}" alt="{{ showcase.title }}" style="width: calc(100% + 2px); height: 205px; object-fit: cover;" loading="lazy">
             {% else %}
-                <img class="rounded-t" src="{{ image_url }}" alt="{{ showcase.title }}" loading="lazy" style="width: calc(100% + 2px); height: 205px; object-fit: cover;">
+                <img class="rounded-t" src="{{ image_url }}" alt="{{ showcase.title }}" loading="lazy" style="width: calc(100% + 2px); height: 205px; object-fit: cover;" loading="lazy">
             {% endif %}
         </div>
         <div class="card-body border-1 border-gray-300 p-6" style="height: 220px;">

--- a/ckanext/montreal_theme/templates/home/snippets/news.html
+++ b/ckanext/montreal_theme/templates/home/snippets/news.html
@@ -4,7 +4,7 @@
     <div class="container md:w-1/3 justify-center">
         <a class="block m-4 hover:border-1 hover:border-solid hover:border-transparent hover:bg-white hover:shadow-xl" href="{{ h.url_for('pages.blog_show', page=blog.name) }}">
             <div class="card-img">
-            <img class="rounded-t" style="width: calc(100% + 2px); height: 205px; object-fit: cover;" src="{{ blog.image }}">
+            <img class="rounded-t" style="width: calc(100% + 2px); height: 205px; object-fit: cover;" src="{{ blog.image }}" loading="lazy">
             </div>
             <div class="card-body border-1 border-gray-300 p-8">
             <p class="text-xl font-bold text-black font-open-sans font-medium mb-4" style="display: block; display: -webkit-box; max_width: 100%; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; text-overflow: ellipsis">{{ blog.title }}</p>

--- a/ckanext/montreal_theme/templates/showcase/snippets/showcase_item.html
+++ b/ckanext/montreal_theme/templates/showcase/snippets/showcase_item.html
@@ -6,7 +6,7 @@
 <div class="sm:w-1/2 lg:w-1/2">
     <a href="{{ h.url_for('showcase.read', id=package.name) }}" class="showcase-item block m-4 hover:border-1 hover:border-solid hover:border-transparent hover:bg-white hover:shadow-xl">
         <div class="card-img">
-            <img class="rounded-t" src="{{ package.image_display_url }}" style="width: calc(100% + 2px); height: 205px; object-fit: cover;">
+            <img class="rounded-t" src="{{ package.image_display_url }}" style="width: calc(100% + 2px); height: 205px; object-fit: cover;" loading="lazy">
         </div>
         <div class="card-body border-1 border-gray-300 p-8" style="height: 300px;">
             <p class="text-xl font-bold text-black font-open-sans font-medium mb-4" style="display: block; display: -webkit-box; max-width:100%; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: ellipsis;">


### PR DESCRIPTION
Lazy loading to img tags on homepage to improve the site performance when big images are inserted in news, applications and organization pages.