### PR TITLE
fix: use organization var in org info snippet to stop anonymous 500s

### DIFF
--- a/ckanext/montreal_theme/templates/organization/snippets/info.html
+++ b/ckanext/montreal_theme/templates/organization/snippets/info.html
@@ -3,18 +3,18 @@
 {% if not g.userobj %}
 
     <div class="mb-gutter md:mr-10 md:pb-2">
-        <a href="{{ group.url }}">
-            <img class="h-24 mb-4" src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" />
+        <a href="{{ url }}">
+            <img class="h-24 mb-4" src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ organization.name }}" />
         </a>
-    
+
     <h2 class="text-primary text-xl font-semibold">
-    {{ group.display_name }}
-    {% if group.state == 'deleted' %}
+    {{ organization.display_name }}
+    {% if organization.state == 'deleted' %}
         [{{ _('Deleted') }}]
     {% endif %}
     </h2>
-    {% if group.description %}
-        <p class="py-2 text-sm">{{ group.description }}</p>
+    {% if organization.description %}
+        <p class="py-2 text-sm">{{ organization.description }}</p>
     {% endif %}
     </div>
 {% else %}


### PR DESCRIPTION
The theme override of `organization/snippets/info.html` reads `group.*`, but CKAN core invokes the snippet without a `group` variable, so anonymous visitors get an HTTP 500 on dataset pages in `montreal-prod`.

## The failure

```
File ".../ckan/templates/package/read_base.html", line 37, in block 'package_organization'
  {% snippet "organization/snippets/info.html", organization=org, show_nums=false, am_following=am_following %}
File ".../ckanext/montreal_theme/templates/organization/snippets/info.html", line 6, in block 'info'
  <a href="{{ group.url }}">
jinja2.exceptions.UndefinedError: 'group' is undefined
```

Core passes `organization=org`. It never passes `group`.

Core's own copy of the snippet normalises the two names up front and then uses `organization` exclusively:

```jinja
{% set organization = organization or group %}
{% set url = h.url_for(organization.type + '.read', id=organization.name, ) %}
```

The override skipped that normalisation, so it only ever worked on organization pages, where the caller happens to supply `group`.

## Why this was invisible internally

The broken branch is gated on `{% if not g.userobj %}`. Logged-in users fall through to the `{% else %}` branch, which already used `organization.*` correctly and renders fine. Only anonymous visitors reach the broken markup, so every signed-in check looked healthy while the public got 500s.

## Impact

Error group in GCP Error Reporting (`amplus-data`): **1,350 occurrences**, first seen 2026-06-08, still firing as of 2026-08-13. Affected routes over a 2-day sample of `montreal-prod`:

```
25  /dataset/activity/<name>
17  /dataset/groups/<name>
 8  /dataset/<name>
```

## The change

`group.*` becomes `organization.*` in the anonymous branch. The `href` uses the top-level `url` that core already computes, matching what the `{% else %}` branch does; organization dicts carry no `url` key, so `organization.url` would not have worked.

Five variable references, no logic or markup change. The `{% else %}` branch is untouched.

## Verification

`origin/main` was confirmed byte-identical to the template running in the `montreal-prod` pod before the change, so this patch applies to what is actually deployed.

Not for merge yet: flagged for review first.