### PR TITLE
fix: drop query params that cannot be Solr field names

### DIFF
--- a/ckanext/montreal_theme/middleware.py
+++ b/ckanext/montreal_theme/middleware.py
@@ -1,0 +1,74 @@
+"""Drop query-string parameters whose names cannot be Solr field names.
+
+CKAN's dataset search view folds every unrecognised query parameter straight
+into the Solr filter query::
+
+    # ckan/views/dataset.py
+    for (param, value) in request.args.items(multi=True):
+        if param not in ['q', 'page', 'sort'] \
+                and len(value) and not param.startswith('_'):
+            if not param.startswith('ext_'):
+                fields.append((param, value))
+                fq += ' %s:"%s"' % (param, value)
+
+The parameter *name* is interpolated with no validation, so a request for
+``?)=x`` builds the filter ``):"x"`` and Solr's lucene parser rejects it::
+
+    org.apache.solr.search.SyntaxError: Cannot parse '):"x" -dataset_type:harvest'
+
+CKAN catches that and logs it at ERROR level, which means any client can fill
+Cloud Error Reporting with noise just by sending an oddly named parameter. The
+line above is identical in 2.9.10, 2.11.5 and current upstream master, so no
+CKAN upgrade removes it.
+
+Stripping such parameters before routing keeps the filter query well formed
+without patching CKAN or trying to unpick ``fq`` after it has been built. Only
+the parameter name is inspected; values are left untouched, so search terms
+still reach Solr exactly as typed.
+"""
+
+import re
+from urllib.parse import unquote_plus
+
+#: A name usable as a Solr field: leading letter, then word characters, dots
+#: or hyphens. Matches every facet CKAN and our extensions actually send
+#: (``tags``, ``res_format``, ``license_id``, ``organization``, ``vocab_*``).
+VALID_PARAM_NAME = re.compile(r'^[A-Za-z][A-Za-z0-9_.-]*$')
+
+
+def is_safe_param(pair):
+    """Whether a raw ``name=value`` pair may stay in the query string.
+
+    Parameters CKAN never forwards to ``fq`` are kept regardless: it skips
+    anything starting with an underscore (facet limits such as
+    ``_tags_limit``) and anything starting with ``ext_`` (extension extras
+    such as ``ext_bbox``), so their names cannot reach the parser.
+    """
+    if not pair:
+        return False
+    name = unquote_plus(pair.split('=', 1)[0])
+    if name.startswith('_') or name.startswith('ext_'):
+        return True
+    return bool(VALID_PARAM_NAME.match(name))
+
+
+def sanitize_query_string(query_string):
+    """Return ``query_string`` without pairs that would corrupt ``fq``."""
+    if not query_string:
+        return query_string
+    kept = [pair for pair in query_string.split('&') if is_safe_param(pair)]
+    return '&'.join(kept)
+
+
+class DropInvalidSearchParams(object):
+    """WSGI middleware that sanitises QUERY_STRING before CKAN routes."""
+
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        query_string = environ.get('QUERY_STRING', '')
+        sanitized = sanitize_query_string(query_string)
+        if sanitized != query_string:
+            environ['QUERY_STRING'] = sanitized
+        return self.app(environ, start_response)

--- a/ckanext/montreal_theme/plugin.py
+++ b/ckanext/montreal_theme/plugin.py
@@ -5,6 +5,7 @@ from ckan.lib.plugins import DefaultTranslation
 
 from ckanext.montreal_theme.views.config import montreal_theme
 from ckanext.montreal_theme import helpers as h
+from ckanext.montreal_theme.middleware import DropInvalidSearchParams
 import ckanext.montreal_theme.cli as cli
 
 class MontrealThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
@@ -15,7 +16,12 @@ class MontrealThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IFacets)
     plugins.implements(plugins.IClick)
     plugins.implements(plugins.IGroupForm, inherit=True)
+    plugins.implements(plugins.IMiddleware, inherit=True)
 
+
+    # IMiddleware
+    def make_middleware(self, app, config):
+        return DropInvalidSearchParams(app)
 
     # IClick
     def get_commands(self):

--- a/ckanext/montreal_theme/tests/test_middleware.py
+++ b/ckanext/montreal_theme/tests/test_middleware.py
@@ -1,0 +1,76 @@
+"""Tests for the query-string sanitiser.
+
+The bad-input cases are taken verbatim from Cloud Error Reporting for
+amplus-data, where they surfaced as Solr ``SyntaxError`` at ERROR level.
+"""
+
+import pytest
+
+from ckanext.montreal_theme.middleware import (
+    DropInvalidSearchParams,
+    sanitize_query_string,
+)
+
+
+@pytest.mark.parametrize('query_string', [
+    # Facets CKAN core sends.
+    'tags=Photographie&tags=Ville-Marie',
+    'res_format=XLS&license_id=cc-by',
+    'organization=ville-de-montreal&groups=infrastructures',
+    # Free-text search, including the values that used to break the parser.
+    'q=311+Montr%C3%A9al',
+    'q=%3Aservice',
+    'q=%29%22',
+    # Sort and pagination.
+    'q=eau&sort=score+desc%2C+metadata_modified+desc&page=2',
+    # Underscore-prefixed facet limits, skipped by CKAN before fq is built.
+    '_tags_limit=0&_groups_limit=0&_res_format_limit=0',
+    # Extension extras, also skipped by CKAN.
+    'ext_bbox=-73.9%2C45.4%2C-73.4%2C45.7',
+    # Dotted and hyphenated names are legal Solr fields.
+    'vocab_theme=transport&extras_custom-field=1',
+    '',
+])
+def test_legitimate_query_strings_are_untouched(query_string):
+    assert sanitize_query_string(query_string) == query_string
+
+
+@pytest.mark.parametrize('query_string,expected', [
+    # Tenable Web App Scanner fuzzing iaea-prod, 2026-08-11.
+    ('%29=tenable_wasscan_name_fuzz', ''),
+    ('%22%27%60--=tenable_wasscan_name_fuzz', ''),
+    # Entity-mangled URLs from crawlers hitting montreal-prod.
+    ('=311+Montr%C3%A9al', ''),
+    ('%3ARuisseaux=1', ''),
+    # A bad parameter must not take the good ones with it.
+    ('tags=eau&%29=x&res_format=CSV', 'tags=eau&res_format=CSV'),
+    ('%29=x&q=montreal', 'q=montreal'),
+])
+def test_invalid_parameter_names_are_dropped(query_string, expected):
+    assert sanitize_query_string(query_string) == expected
+
+
+def test_values_are_never_inspected():
+    """Only the name decides; a value may contain any Solr metacharacter."""
+    query_string = 'q=%29%3A%22%7B%21xjoin%7D'
+    assert sanitize_query_string(query_string) == query_string
+
+
+def test_middleware_rewrites_environ():
+    captured = {}
+
+    def app(environ, start_response):
+        captured['qs'] = environ['QUERY_STRING']
+        return []
+
+    environ = {'QUERY_STRING': 'tags=eau&%29=x'}
+    DropInvalidSearchParams(app)(environ, lambda *a: None)
+
+    assert captured['qs'] == 'tags=eau'
+    assert environ['QUERY_STRING'] == 'tags=eau'
+
+
+def test_middleware_leaves_clean_requests_alone():
+    environ = {'QUERY_STRING': 'tags=eau'}
+    DropInvalidSearchParams(lambda e, s: [])(environ, lambda *a: None)
+    assert environ['QUERY_STRING'] == 'tags=eau'


### PR DESCRIPTION
Any URL parameter name goes straight into the Solr filter query, so a request such as `?)=x` produces the filter `):"x"` and Solr rejects it. CKAN logs that at ERROR level, which means any client can fill Cloud Error Reporting with noise on demand.

## The defect

```python
# ckan/views/dataset.py
for (param, value) in request.args.items(multi=True):
    if param not in [u'q', u'page', u'sort'] \
            and len(value) and not param.startswith(u'_'):
        if not param.startswith(u'ext_'):
            fields.append((param, value))
            fq += u' %s:"%s"' % (param, value)      # param interpolated unvalidated
```

Solr's lucene parser then fails:

```
org.apache.solr.search.SyntaxError: Cannot parse '):"x" -dataset_type:harvest':
  Encountered " ")" ") "" at line 1, column 0.
```

## Observed sources in amplus-data

```
?)=tenable_wasscan_name_fuzz        Tenable web app scanner, iaea-prod, 2026-08-11
?"'`--=tenable_wasscan_name_fuzz    Tenable web app scanner, iaea-prod, 2026-08-11
?=311 Montréal                      entity-mangled crawler URLs, montreal-prod, continuous
```

`montreal-prod` produces these at 1-2 per hour continuously. Over 7 days: 199 from the scanner burst, plus the steady crawler trickle.

## Not a user-facing outage

Worth stating plainly so this is prioritised correctly. CKAN catches the failure:

```python
except SearchError as se:
    log.error(u'Dataset search error: %r', se.args)
    extra_vars[u'query_error'] = True
    extra_vars[u'search_facets'] = {}
    extra_vars[u'page'] = Page(collection=[])
```

The visitor gets a normal page with a query-error message, HTTP 200. `montreal-prod` served exactly one 500 in a full day, against 281 404s. This PR is about stopping the ERROR log noise and removing an easy way for bots to generate it, not about fixing broken search.

## No CKAN upgrade fixes this

The line is byte-identical in `2.9.10`, `2.11.5`, upstream `dev-v2.12` and current `master`. CKAN 2.11 added `_check_query_parser` to block `{!...}` local-param injection in query *values*, but nothing validates the field *name*. `montreal-prod` is already on 2.11.5 and generates more of these than the 2.9 sites do.

## The change

A WSGI middleware drops query-string pairs whose name cannot be a Solr field, before routing. This keeps `fq` well formed without patching CKAN or trying to unpick the filter query after it has been built.

- Only the parameter **name** is inspected against `^[A-Za-z][A-Za-z0-9_.-]*$`. Values pass through untouched, so search terms still reach Solr exactly as typed, metacharacters and all.
- Names starting with `_` or `ext_` are always kept: CKAN skips those before building `fq`, so they can never reach the parser.
- Registered via `IMiddleware` with `inherit=True`. Same `make_middleware(app, config)` signature in 2.9.10 and 2.11.5, and CKAN keeps using the original `flask_app` for login-manager wiring after the middleware loop, so returning a plain WSGI wrapper is the supported pattern.

## Tests

20 tests, all passing. Bad inputs are the verbatim strings from Error Reporting; good inputs cover core facets, free-text `q` containing Solr metacharacters, sort, pagination, `_*_limit`, `ext_bbox`, and dotted/hyphenated field names.

```
20 passed in 0.02s
```

## Notes

- Montreal only, by design. Not touching other clients' extensions.
- This is a workaround for a core bug that still affects upstream master, so it is worth an upstream PR to `ckan/ckan` so we stop carrying it.
